### PR TITLE
Add support for BER Enum type (0x0a)

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -273,6 +273,9 @@ func (ctx *Context) getUniversalTag(objType reflect.Type, opts *fieldOptions) (e
 	case nullType:
 		elem.tag = tagNull
 		elem.decoder = ctx.decodeNull
+	case enumType:
+		elem.tag = tagEnum
+		elem.decoder = ctx.decodeInt
 	default:
 		// Generic types:
 		elem = ctx.getUniversalTagByKind(objType, opts)

--- a/encode.go
+++ b/encode.go
@@ -96,6 +96,9 @@ func (ctx *Context) encodeValue(value reflect.Value, opts *fieldOptions) (raw *r
 	case nullType:
 		raw.Tag = tagNull
 		encoder = ctx.encodeNull
+	case enumType:
+		raw.Tag = tagEnum
+		encoder = ctx.encodeInt
 	}
 
 	if encoder == nil {

--- a/raw.go
+++ b/raw.go
@@ -24,6 +24,7 @@ const (
 	tagOctetString     = 0x04
 	tagNull            = 0x05
 	tagOid             = 0x06
+	tagEnum            = 0x0a  // treat as Int
 	tagSequence        = 0x10
 	tagSet             = 0x11
 	tagPrintableString = 0x13

--- a/types.go
+++ b/types.go
@@ -13,6 +13,7 @@ var (
 	bitStringType = reflect.TypeOf(BitString{})
 	oidType       = reflect.TypeOf(Oid{})
 	nullType      = reflect.TypeOf(Null{})
+	enumType      = reflect.TypeOf(Enum(0))
 )
 
 /*
@@ -237,6 +238,10 @@ func (ctx *Context) decodeString(data []byte, value reflect.Value) error {
 /*
  * Custom types
  */
+
+// ENUM
+
+type Enum int
 
 // BIT STRING
 


### PR DESCRIPTION
The decoding/encoding is the same as for an `Int`, so all we need is to recognize
the correct type.

To use, declare with the `Enum` type, e.g.:

```
import "github.com/zmap/asn1"

struct example {
    MyVar   asn1.Enum
}
```